### PR TITLE
chore(deps): group minor + patch dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,21 @@
+---
 version: 2
 updates:
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+  groups:
+    minor-and-patch:
+      update-types:
+      - minor
+      - patch
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  groups:
+    minor-and-patch:
+      update-types:
+      - minor
+      - patch


### PR DESCRIPTION
Adds a `groups` block to `.github/dependabot.yml` bundling **minor + patch** updates into one PR per ecosystem; **majors stay as separate PRs**. Stops the individual-PR flood from rebuilding. Config-only. For human review + merge.